### PR TITLE
Restart rather than start Postgres

### DIFF
--- a/mac
+++ b/mac
@@ -48,7 +48,7 @@ log_info "Installing Postgres, a good open source relational database ..."
   brew install postgresql@14
 
 log_info "Starting Postgres ..."
-  brew services start postgresql@14
+  brew services restart postgresql@14
 
 log_info "Installing Redis, a good key-value database ..."
   brew install redis


### PR DESCRIPTION
When running the script multiple times (because, say, ruby won't install properly), it will fail to start Postgres if it's already started. I believe this version of the command works whether Postgres has been started in the past or not.