### PR TITLE
Skip if Ruby version already installed

### DIFF
--- a/mac
+++ b/mac
@@ -89,7 +89,7 @@ log_info "Installing coreutils ..."
 ruby_version="2.7.3"
 
 log_info "Installing Ruby $ruby_version ..."
-  rbenv install "$ruby_version"
+  rbenv install -s "$ruby_version"
 
 log_info "Setting $ruby_version as global default Ruby ..."
   rbenv global "$ruby_version"


### PR DESCRIPTION
If you already have the designated version of Ruby, just skip this step. Without this option, you must wait for Ruby to be needlessly reinstalled each time you run the script. No real risk to skipping unless you have a screwed up install in the first place.