### PR TITLE
Restart rather than start Redis

### DIFF
--- a/mac
+++ b/mac
@@ -54,7 +54,7 @@ log_info "Installing Redis, a good key-value database ..."
   brew install redis
 
 log_info "Starting Redis ..."
-  brew services start redis
+  brew services restart redis
 
 log_info "Installing and linking ImageMagick, to crop and resize images ..."
   brew install imagemagick


### PR DESCRIPTION
Doesn't throw an error if Redis is already started, but doesn't update to the latest Redis if it's just been installed. (See: https://github.com/discourse/prometheus_exporter/pull/250)